### PR TITLE
Add repo exclusion functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 _out/
+.vscode/launch.json


### PR DESCRIPTION
This PR will allow the script to now accept a list of repos to exclude from the process.

Any repos added into an "exclude-repos" file will be removed from the list of repos that would have had a pull request made for. This can either be the list generated from the "include-repos" file, or the list of all repos in the org.